### PR TITLE
Replace standard json serialization by pandas.io.json

### DIFF
--- a/pandas_highcharts/core.py
+++ b/pandas_highcharts/core.py
@@ -1,18 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import pandas
-import datetime
-import json
-import time
 import copy
-
-
-class JSONEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, (pandas.tslib.Timestamp, datetime.date, datetime.datetime)):
-            t = time.mktime(obj.timetuple()) - time.mktime((1970, 1, 1, 0, 0, 0, 0, 0, 0))
-            return int(t * 1000)
-        return json.JSONEncoder.default(self, obj)
 
 
 _pd2hc_kind = {
@@ -41,6 +30,8 @@ def pd2hc_linestyle(linestyle):
         raise ValueError("%(linestyle)s linestyles are not yet supported" % locals())
     return _pd2hc_linestyle[linestyle]
 
+def json_encode(obj):
+    return pandas.io.json.dumps(obj)
 
 def serialize(df, output_type="javascript", *args, **kwargs):
     def serialize_chart(df, output, *args, **kwargs):
@@ -195,4 +186,4 @@ def serialize(df, output_type="javascript", *args, **kwargs):
     serialize_zoom(df_copy, output, *args, **kwargs)
     if output_type == "json":
         return output
-    return "new Highcharts.Chart(%s);" % JSONEncoder().encode(output)
+    return "new Highcharts.Chart(%s);" % pandas.io.json.dumps(output)

--- a/pandas_highcharts/tests.py
+++ b/pandas_highcharts/tests.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from core import serialize, JSONEncoder
+from core import serialize, json_encode
 import datetime
 import pandas
 import pytz
@@ -61,7 +61,7 @@ class CoreTest(TestCase):
         # self.assertTrue(False)
     
     def test_jsonencoder(self):
-        self.assertEqual(JSONEncoder().encode(datetime.date(1970, 1, 1)), "0")
-        self.assertEqual(JSONEncoder().encode(datetime.date(2015, 1, 1)), "1420070400000")
-        self.assertEqual(JSONEncoder().encode(datetime.datetime(2015, 1, 1)), "1420070400000")
-        self.assertEqual(JSONEncoder().encode(pandas.tslib.Timestamp(1420070400000000000)), "1420070400000")
+        self.assertEqual(json_encode(datetime.date(1970, 1, 1)), "0")
+        self.assertEqual(json_encode(datetime.date(2015, 1, 1)), "1420070400000")
+        self.assertEqual(json_encode(datetime.datetime(2015, 1, 1)), "1420070400000")
+        self.assertEqual(json_encode(pandas.tslib.Timestamp(1420070400000000000)), "1420070400000")


### PR DESCRIPTION
- Use the ultrajson, aka ujson, C lib with Python bindings
- can handle numpy.int64
- can handle pandas TimeStamp, datetime and date Python objects
- Remove the JSONEncode
- Clean some useless import
- Update the related test cases

closes #4
closes #5
