### PR TITLE
display: add the pretty_params function

### DIFF
--- a/pandas_highcharts/display.py
+++ b/pandas_highcharts/display.py
@@ -5,6 +5,8 @@
 
 import string
 import random
+import json
+import copy
 
 from IPython.core import getipython
 from IPython.core.display import display, HTML
@@ -52,3 +54,31 @@ def display_charts(df, chart_type="default", render_to=None, **kwargs):
     <script type="text/javascript">{data}</script>"""
     return display(HTML(content.format(chart_id=chart_id,
                                        data=json_data)))
+
+def _series_data_filter(data):
+    """Replace each 'data' key in the list stored under 'series' by "[...]".
+
+    Use to not store and display the series data when you just want display and
+    modify the Highcharts parameters.
+
+    data: dict
+        Serialized DataFrame in a dict for Highcharts
+
+    Returns: a dict with filtered values
+
+    See also `core.serialize`
+    """
+    data = copy.deepcopy(data)
+    if "series" in data:
+        for series in data["series"]:
+            series["data"] = "[...]"
+    return data
+
+def pretty_params(data, indent=2):
+    """Pretty print your Highcharts params (into a JSON).
+
+    data: dict
+        Serialized DataFrame in a dict for Highcharts
+    """
+    data_to_print = _series_data_filter(data)
+    print(json.dumps(data_to_print, indent=indent))


### PR DESCRIPTION
Hi,

Quite useful function to print the serialized DataFrame without all series data but just Highcharts parameters. Thus, it can be easier to take a Highcharts example, see the options and modify the dictionary returned by `core.serialized` with the `output_type="json"`parameter.

``` python
from pandas_highcharts.core import serialize
from pandas_highcharts.display import pretty_params
# Suppose you have a DataFrame named 'df'
data = serialize(df, render_to="content", output_type="json")
pretty_params(data)
```

can display something like:

```
{
  "series": [
    {
      "data": "[...]",
      "name": "Y",
      "yAxis": 0
    },
    {
      "data": "[...]",
      "name": "X",
      "yAxis": 0
    },
    {
      "data": "[...]",
      "name": "Z",
      "yAxis": 0
    }
  ],
  "legend": {
    "enabled": true
  },
  "chart": {
    "renderTo": "content"
  },
  "xAxis": {
    "type": "datetime"
  },
  "yAxis": [
    {}
  ]
}
```
