### PR TITLE
Fixes mix content error in web browsers when jupyter runs on https

### DIFF
--- a/pandas_highcharts/display.py
+++ b/pandas_highcharts/display.py
@@ -15,8 +15,8 @@ from core import serialize
 
 
 # Note that Highstock includes all Highcharts features.
-HIGHCHARTS_SCRIPTS = """<script src="http://code.highcharts.com/stock/highstock.js"></script>
-<script src="http://code.highcharts.com/modules/exporting.js"></script>
+HIGHCHARTS_SCRIPTS = """<script src="//code.highcharts.com/stock/highstock.js"></script>
+<script src="//code.highcharts.com/modules/exporting.js"></script>
 """
 
 # Automatically insert the script tag into your Notebook.


### PR DESCRIPTION
Currently `http` is hard coded which is fine but it yield browser warning on jupyter running on `https`. This PR aims to fix that.
