### PR TITLE
Percent change and stacked bar charts

### DIFF
--- a/pandas_highcharts/core.py
+++ b/pandas_highcharts/core.py
@@ -106,7 +106,7 @@ def serialize(df, output_type="javascript", chart_type="default", *args, **kwarg
                 if kwargs.get('polar'):
                     d['data'] = [v for k, v in d['data']]
                 if kwargs.get('compare'):
-                    d['compare'] = 'percent'
+                    d['compare'] = kwargs.get('compare')  # either `value` or `percent`
                 if kwargs.get("kind") in ("area", "bar") and kwargs.get("stacked", True):
                     d["stacking"] = 'normal'
                 if kwargs.get("style"):

--- a/pandas_highcharts/core.py
+++ b/pandas_highcharts/core.py
@@ -9,6 +9,7 @@ _pd2hc_kind = {
     "barh": "bar",
     "area": "area",
     "line": "line",
+    "spline": "spline",
     "pie": "pie"
 }
 
@@ -104,7 +105,9 @@ def serialize(df, output_type="javascript", chart_type="default", *args, **kwarg
                 }
                 if kwargs.get('polar'):
                     d['data'] = [v for k, v in d['data']]
-                if kwargs.get("kind") == "area" and kwargs.get("stacked", True):
+                if kwargs.get('compare'):
+                    d['compare'] = 'percent'
+                if kwargs.get("kind") in ("area", "bar") and kwargs.get("stacked", True):
                     d["stacking"] = 'normal'
                 if kwargs.get("style"):
                     d["dashStyle"] = pd2hc_linestyle(kwargs["style"].get(name, "-"))

--- a/pandas_highcharts/tests.py
+++ b/pandas_highcharts/tests.py
@@ -43,6 +43,9 @@ class CoreTest(TestCase):
         obj = serialize(df, render_to="chart", output_type="json", kind="area", stacked=True)
         self.assertEqual(obj.get("series")[0].get("stacking"), "normal")
 
+        obj = serialize(df, render_to="chart", output_type="json", kind="bar", stacked=True)
+        self.assertEqual(obj.get("series")[0].get("stacking"), "normal")
+
         obj = serialize(df, render_to="chart", output_type="json", grid=True)
         self.assertEqual(obj.get('xAxis', {}).get('gridLineDashStyle'), 'Dot')
         self.assertEqual(obj.get('xAxis', {}).get('gridLineWidth'), 1)
@@ -70,6 +73,9 @@ class CoreTest(TestCase):
 
         obj = serialize(df, render_to="chart", output_type="json", polar=True, x='s', y=['a'])
         self.assertTrue(obj.get('chart', {}).get('polar'))
+
+        obj = serialize(df, render_to="chart", compare='percent', output_type="json")
+        self.assertTrue(obj.get('series', {})[0].get('compare') == 'percent')
 
     def test_jsonencoder(self):
         self.assertEqual(json_encode(datetime.date(1970, 1, 1)), "0")


### PR DESCRIPTION
A few minor changes:
- Allowing for `spline` "kind"
- Allowing for stacked column charts
- Allowing for "plotOptions.series.compare" charts: http://api.highcharts.com/highstock#plotOptions.series.compare
