### PR TITLE
Python3 fixes

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,19 @@
+Running tests
+=============
+
+To run the tests, install the dependencies in requirements.txt and also nose::
+
+    pip install nose
+
+Then run::
+
+    nosetests pandas_highcharts
+
+
+Alternatively, to run the tests on all supported versions, install 'tox'::
+
+    pip install tox
+
+Then just run tox::
+
+    tox

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,6 @@
-include pandas_highcharts/core.py
-include pandas_highcharts/display.py
-include pandas_highcharts/tests.py
 include requirements.txt
+include *.ipynb
+include *.yml
+include LICENSE
+include tox.ini
+recursive-include pandas_highcharts *.csv

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include requirements.txt
 include *.ipynb
 include *.yml
+include *.rst
 include LICENSE
 include tox.ini
 recursive-include pandas_highcharts *.csv

--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,11 @@ In your templates
       new Highcharts.Chart({{chart|safe}});
     </script>
 
+Contributing
+------------
+
+See CONTRIBUTING.rst for information on how to contribute to pandas-highcharts.
+
 More examples
 -------------
 

--- a/pandas_highcharts/core.py
+++ b/pandas_highcharts/core.py
@@ -100,7 +100,7 @@ def serialize(df, output_type="javascript", chart_type="default", *args, **kwarg
                 d = {
                     "name": name if not sec or not kwargs.get("mark_right", True) else name + " (right)",
                     "yAxis": int(sec),
-                    "data": zip(df.index, data.tolist())
+                    "data": list(zip(df.index, data.tolist()))
                 }
                 if kwargs.get('polar'):
                     d['data'] = [v for k, v in d['data']]

--- a/pandas_highcharts/tests.py
+++ b/pandas_highcharts/tests.py
@@ -16,6 +16,11 @@ class CoreTest(TestCase):
         self.assertEqual(type(serialize(df, render_to="chart")), str)
         obj = serialize(df, render_to="chart", output_type="json")
         self.assertEqual(type(obj), dict)
+        self.assertTrue('series' in obj)
+        for series in obj['series']:
+            if series['name'] == 'a':
+                self.assertTrue('data' in series)
+                self.assertEqual(series['data'], [(0, 1), (1, 2)])
 
         obj = serialize(df, render_to="chart", output_type="json", zoom="xy")
         self.assertTrue("chart" in obj)

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,7 @@ setup(
     license='LICENSE',
     description='pandas-highcharts is a Python package which allows you to easily build Highcharts plots with pandas.DataFrame objects.',
     url='https://github.com/gtnx/pandas-highcharts',
-    install_requires=map(
-        lambda line: line.strip("\n"),
-        open("requirements.txt", "r").readlines()
-    ),
+    install_requires=[line.strip("\n") for line in open("requirements.txt", "r").readlines()],
     include_package_data=True,
     packages=find_packages(),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,2 +1,9 @@
+[tox]
+envlist = py26,py27,py34
+
+[testenv]
+deps = nose
+commands = nosetests --with-cover --cover-package pandas_highcharts pandas_highcharts
+
 [flake8]
 ignore = E501


### PR DESCRIPTION
This first adds some tox.ini entries so that I (and others) could easily run tests on all environments by just typing "tox".

(tox has a lot more features e.g. easily test on different versions of pandas, for instance, if necessary).

I then fixed the actual Python 3 issues, in a way that was compatible with Python 2.6/2.7. I added a test that fails without my patch (due to the fact that zip doesn't return a list on Python 3.x).

Thanks!
