### PR TITLE
Created some initial configs for stock charts

### DIFF
--- a/pandas_highcharts/core.py
+++ b/pandas_highcharts/core.py
@@ -87,6 +87,12 @@ def serialize(df, output_type="javascript", chart_type="default", *args, **kwarg
     def serialize_plotOptions(df, output, *args, **kwargs):
         pass
 
+    def serialize_rangeSelector(df, output, *args, **kwargs):
+        output["rangeSelector"] = {
+            "allButtonsEnabled": kwargs.get("range_all_buttons_enabled", False),
+            "selected": kwargs.get("range_selected", 5)
+        }
+
     def serialize_series(df, output, *args, **kwargs):
         def is_secondary(c, **kwargs):
             return c in kwargs.get("secondary_y", [])
@@ -206,5 +212,6 @@ def serialize(df, output_type="javascript", chart_type="default", *args, **kwarg
     if output_type == "json":
         return json_encode(output)
     if chart_type == "stock":
+        serialize_rangeSelector(df, output, *args, **kwargs)
         return "new Highcharts.StockChart(%s);" % json_encode(output)
     return "new Highcharts.Chart(%s);" % json_encode(output)

--- a/pandas_highcharts/core.py
+++ b/pandas_highcharts/core.py
@@ -207,11 +207,12 @@ def serialize(df, output_type="javascript", chart_type="default", *args, **kwarg
     serialize_xAxis(df_copy, output, *args, **kwargs)
     serialize_yAxis(df_copy, output, *args, **kwargs)
     serialize_zoom(df_copy, output, *args, **kwargs)
+    if chart_type == "stock":
+        serialize_rangeSelector(df, output, *args, **kwargs)
     if output_type == "dict":
         return output
     if output_type == "json":
         return json_encode(output)
     if chart_type == "stock":
-        serialize_rangeSelector(df, output, *args, **kwargs)
         return "new Highcharts.StockChart(%s);" % json_encode(output)
     return "new Highcharts.Chart(%s);" % json_encode(output)

--- a/pandas_highcharts/tests.py
+++ b/pandas_highcharts/tests.py
@@ -79,6 +79,10 @@ class CoreTest(TestCase):
 
         obj = serialize(df, render_to="chart", output_type="dict", polar=True, x='s', y=['a'])
         self.assertTrue(obj.get('chart', {}).get('polar'))
+        
+        obj = serialize(df, render_to="chart", output_type="dict", kind="stock", range_all_buttons_enabled=True, range_selected=3)
+        self.assertEqual(obj.get("chart").get("rangeSelector", {}).get("allButtonsEnabled", False), True)
+        self.assertEqual(obj.get("chart").get("rangeSelector", {}).get("selected", 5), 3)
 
         df2 = pandas.DataFrame({'s': [2, 1]}, index=['b', 'a'])
         obj = serialize(df2, render_to='chart', output_type='dict', sort_columns=True)

--- a/pandas_highcharts/tests.py
+++ b/pandas_highcharts/tests.py
@@ -81,8 +81,8 @@ class CoreTest(TestCase):
         self.assertTrue(obj.get('chart', {}).get('polar'))
         
         obj = serialize(df, render_to="chart", output_type="dict", chart_type="stock", range_all_buttons_enabled=True, range_selected=3)
-        self.assertEqual(obj.get("chart").get("rangeSelector", {}).get("allButtonsEnabled", False), True)
-        self.assertEqual(obj.get("chart").get("rangeSelector", {}).get("selected", 5), 3)
+        self.assertEqual(obj.get("rangeSelector", {}).get("allButtonsEnabled", False), True)
+        self.assertEqual(obj.get("rangeSelector", {}).get("selected", 5), 3)
 
         df2 = pandas.DataFrame({'s': [2, 1]}, index=['b', 'a'])
         obj = serialize(df2, render_to='chart', output_type='dict', sort_columns=True)

--- a/pandas_highcharts/tests.py
+++ b/pandas_highcharts/tests.py
@@ -80,7 +80,7 @@ class CoreTest(TestCase):
         obj = serialize(df, render_to="chart", output_type="dict", polar=True, x='s', y=['a'])
         self.assertTrue(obj.get('chart', {}).get('polar'))
         
-        obj = serialize(df, render_to="chart", output_type="dict", kind="stock", range_all_buttons_enabled=True, range_selected=3)
+        obj = serialize(df, render_to="chart", output_type="dict", chart_type="stock", range_all_buttons_enabled=True, range_selected=3)
         self.assertEqual(obj.get("chart").get("rangeSelector", {}).get("allButtonsEnabled", False), True)
         self.assertEqual(obj.get("chart").get("rangeSelector", {}).get("selected", 5), 3)
 


### PR DESCRIPTION
Created two named parameters that are passed from "display_charts" for rangeSelector options `[1]`:
- range_all_buttons_enabled: add "allButtonsEnabled" key `[2]`. Defaults to False, as the API.
- range_selected: add "selected" key `[3]`. Defaults to 5 (_All_ button, same behaviour as 'undefined')

Refs:

`[1]`: http://api.highcharts.com/highstock#rangeSelector
`[2]`: http://api.highcharts.com/highstock#rangeSelector.allButtonsEnabled
`[3]`: http://api.highcharts.com/highstock#rangeSelector.selected
